### PR TITLE
Add pins definition for M5STACK_NO_PSRAM; 

### DIFF
--- a/camera_pins.h
+++ b/camera_pins.h
@@ -102,6 +102,26 @@
 //#define LED_OFF        LOW //
 //#define LAMP_PIN        x  // LED FloodLamp.
 
+// Common M5 Stack without PSRAM
+#elif defined(CAMERA_MODEL_M5STACK_NO_PSRAM)
+#define PWDN_GPIO_NUM -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM 27
+#define SIOD_GPIO_NUM 25
+#define SIOC_GPIO_NUM 23
+#define Y9_GPIO_NUM 19
+#define Y8_GPIO_NUM 36
+#define Y7_GPIO_NUM 18
+#define Y6_GPIO_NUM 39
+#define Y5_GPIO_NUM 5
+#define Y4_GPIO_NUM 34
+#define Y3_GPIO_NUM 35
+#define Y2_GPIO_NUM 17
+#define VSYNC_GPIO_NUM 22
+#define HREF_GPIO_NUM 26
+#define PCLK_GPIO_NUM 21
+// Note NO PSRAM,; so maximum working resolution is XGA 1024×768
+
 
 // AI Thinker
 // https://github.com/SeeedDocument/forum_doc/raw/master/reg/ESP32_CAM_V1.6.pdf

--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -25,6 +25,7 @@
 //#define CAMERA_MODEL_ESP_EYE
 //#define CAMERA_MODEL_M5STACK_PSRAM
 //#define CAMERA_MODEL_M5STACK_WIDE
+//#define CAMERA_MODEL_M5STACK_NO_PSRAM
 #define CAMERA_MODEL_AI_THINKER
 
 // Select camera module used on the board


### PR DESCRIPTION
- See https://randomnerdtutorials.com/esp32-cam-video-streaming-face-recognition-arduino-ide/#comment-406803 for more
- Also discussed on: https://randomnerdtutorials.com/esp32-cam-troubleshooting-guide/
- Addresses: sp_camera_fb_get(): Failed to get the frame on time!