### PR TITLE
Portal page with hardcoded IP addresses

### DIFF
--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -103,8 +103,9 @@ DNSServer dnsServer;
 bool captivePortal = false;
 char apName[64] = "Undefined";
 
-// The stream URL
-char streamURL[64] = {"Undefined"};  // Stream URL to pass to the app.
+// The app and stream URLs
+char httpURL[64] = {"Undefined"};
+char streamURL[64] = {"Undefined"};
 
 // This will be displayed to identify the firmware
 char myVer[] PROGMEM = __DATE__ " @ " __TIME__;
@@ -505,7 +506,6 @@ void setup() {
     startCameraServer(httpPort, streamPort);
     
     // Construct the app and stream URLs
-    char httpURL[64] = {"Unknown"};
     if (httpPort != 80) {
         sprintf(httpURL, "http://%d.%d.%d.%d:%d/", ip[0], ip[1], ip[2], ip[3], httpPort);
     } else {

--- a/index_other.h
+++ b/index_other.h
@@ -2,7 +2,7 @@
  * simpleviewer and streamviewer
  */
 
- const uint8_t index_simple_html[] = R"=====(<!doctype html>
+const uint8_t index_simple_html[] = R"=====(<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -283,7 +283,7 @@ size_t index_simple_html_len = sizeof(index_simple_html)-1;
 
 /* Stream Viewer */
 
- const uint8_t streamviewer_html[] = R"=====(<!doctype html>
+const uint8_t streamviewer_html[] = R"=====(<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -433,28 +433,31 @@ size_t index_simple_html_len = sizeof(index_simple_html)-1;
 
 size_t streamviewer_html_len = sizeof(streamviewer_html)-1;
 
-/* Prototype Captive Portal page */
+/* Prototype Captive Portal page 
+   we replace the <> delimited strings with correct values as it is served */
 
- const uint8_t portal_html[] = R"=====(<!doctype html>
-<html><head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+const std::string portal_html = R"=====(<!doctype html>
+<html>
+  <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title id="title">ESP32-CAM portal</title>
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="stylesheet" type="text/css" href="/style.css">
- </head>
-  <body>
-    <img src="/logo.svg" style="position: relative; float: right;">
-    <h1>ESP32 cam access portal</h1>
-    <div class="input-group">
-    <a href="/?view=simple" title="Click here for a simple view with minimum control" style="text-decoration: none;"><button>Simple Viewer</button></a>
-    <a href="/?view=full" title="Click here for the main camera page with full controls" style="text-decoration: none;"><button>Full Viewer</button></a>
+    <title id="title"><CAMNAME> - portal</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="<APPURL>favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="<APPURL>favicon-16x16.png">
+    <link rel="stylesheet" type="text/css" href="<APPURL>style.css">
+  </head>
+  <body style="text-align: center;">
+    <img src="<APPURL>logo.svg" style="position: relative; float: right;">
+    <h1><CAMNAME> - access portal</h1>
+    <div class="input-group" style="margin: auto; width: max-content;">
+      <a href="<APPURL>?view=simple" title="Click here for a simple view with minimum control" style="text-decoration: none;" target="_blank">
+      <button>Simple Viewer</button></a>
+      <a href="<APPURL>?view=full" title="Click here for the main camera page with full controls" style="text-decoration: none;" target="_blank">
+      <button>Full Viewer</button></a>
+      <a href="<STREAMURL>view" title="Click here for the dedicated stream viewer" style="text-decoration: none;" target="_blank">
+      <button>Stream Viewer</button></a>
     </div>
     <hr>
-    <a href="/dump" title="Information dump page" target="_blank">Camera Details</a><br>
-    <a href="https://github.com/easytarget/esp32-cam-webserver" title="Code homepage on GitHub">ESP32 cam webserver on GitHub</a>
-</body></html>)=====";
-
-size_t portal_html_len = sizeof(portal_html)-1;
+    <a href="<APPURL>dump" title="Information dump page" target="_blank">Camera Details</a><br>
+  </body>
+</html>)=====";


### PR DESCRIPTION
Rather then use relative URLs on the portal page, push the full IP based URL to links.