### PR TITLE
Disable WiFi Powersave for better responsiveness

### DIFF
--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -247,6 +247,11 @@ void WifiSetup() {
     delay(100);
     flashLED(300);
     Serial.println("Starting WiFi");
+
+    // Disable poser saving on WiFi to improve responsiveness 
+    // (https://github.com/espressif/arduino-esp32/issues/1484)
+    WiFi.setSleep(false);
+
     Serial.print("Known external SSIDs: ");
     if (stationCount > firstStation) {
         for (int i=firstStation; i < stationCount; i++) Serial.printf(" '%s'", stationList[i].ssid);

--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -248,7 +248,7 @@ void WifiSetup() {
     flashLED(300);
     Serial.println("Starting WiFi");
 
-    // Disable poser saving on WiFi to improve responsiveness 
+    // Disable power saving on WiFi to improve responsiveness 
     // (https://github.com/espressif/arduino-esp32/issues/1484)
     WiFi.setSleep(false);
 


### PR DESCRIPTION
Looks like doing this can resolve a whole bunch of wifi powersave related lags and slow responses that can happen even while the WiFi is active.

See: https://github.com/espressif/arduino-esp32/issues/1484

This might increase power consumption on the Cam module, but since they draw quite a bit of power anyway I'm not going to let this stop me implementing it.