### PR TITLE
Handle corrupt preferences files

### DIFF
--- a/storage.h
+++ b/storage.h
@@ -2,6 +2,7 @@
 #include "SPIFFS.h"
 
 #define FORMAT_SPIFFS_IF_FAILED true
+#define PREFERENCES_MAX_SIZE 500
 
 #define PREFERENCES_FILE "/esp32cam-preferences.json"
 


### PR DESCRIPTION
SPIFFS has a nasty bug where reading the preferences file produced an infinite supply of data, locking the loadPrefs() function up during startup.
Fix this by adding a check on sizes and wether more data is returned than the declared size; if so scrub the preferences file since it is corrupt and proceed with defaults.