### PR TITLE
add lamp warning unicode in html for #142

### DIFF
--- a/index_other.h
+++ b/index_other.h
@@ -30,10 +30,10 @@ const uint8_t index_simple_html[] = R"=====(<!doctype html>
           <input type="checkbox" id="nav-toggle-cb">
             <nav id="menu" style="width:24em;">
               <div class="input-group hidden" id="lamp-group">
-                <label for="lamp">Light</label>
+                <label for="lamp">Lamp</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="action-setting">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group" id="framesize-group">
                 <label for="framesize">Resolution</label>

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -36,10 +36,10 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
           <input type="checkbox" id="nav-toggle-cb" checked="checked">
             <nav id="menu">
               <div class="input-group hidden" id="lamp-group">
-                <label for="lamp">Light</label>
+                <label for="lamp">Lamp</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group hidden" id="autolamp-group">
                 <label for="autolamp">Auto Lamp</label>

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -36,10 +36,10 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
           <input type="checkbox" id="nav-toggle-cb" checked="checked">
             <nav id="menu">
               <div class="input-group hidden" id="lamp-group">
-                <label for="lamp">Light</label>
+                <label for="lamp">Lamp</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group hidden" id="autolamp-group">
                 <label for="autolamp">Auto Lamp</label>


### PR DESCRIPTION
The Simple & Full html view will now look like:

![image](https://user-images.githubusercontent.com/6502474/126402774-3ea013ee-113f-4f6b-afa0-77f3b3dbea4a.png)

I felt it important to put the warning unicode next to full brightness.  Ideally I would like a text label of message saying something along the lines of: "Warning: LED lamp is very bright and may damage eyes! Be careful to not increase too much!"

Also I changed "Light" to "Lamp" because "Lamp" is more specific.  (Maybe "LED Lamp" might be better to, I don't know...or even using the lightbulb unicode symbol.)  But mainly I just wanted to get that warning unicode symbol in.