### PR TITLE
updateConfig when move slider too

### DIFF
--- a/index_other.h
+++ b/index_other.h
@@ -258,6 +258,11 @@ const uint8_t index_simple_html[] = R"=====(<!doctype html>
       .forEach(el => {
         el.onchange = () => updateConfig(el)
       })
+    document
+      .querySelectorAll('input[type="range"]')
+      .forEach(el => {
+        el.oninput = () => updateConfig(el)
+      })
 
     // Custom actions
     // Detection and framesize

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -498,6 +498,11 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
       .forEach(el => {
         el.onchange = () => updateConfig(el)
       })
+    document
+      .querySelectorAll('input[type="range"]')
+      .forEach(el => {
+        el.oninput = () => updateConfig(el)
+      })
 
     // Custom actions
     // Gain

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -510,6 +510,11 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
       .forEach(el => {
         el.onchange = () => updateConfig(el)
       })
+    document
+      .querySelectorAll('input[type="range"]')
+      .forEach(el => {
+        el.oninput = () => updateConfig(el)
+      })
 
     // Custom actions
     // Gain


### PR DESCRIPTION
onchange only would trigger updateConfig when user releases the mouse from sliders.

Adding oninput also allows updateConfig when dragging the sliders, which is nice cause user gets immediate feedback of the changes.

A big reason why I want this change is because the LED Lamp is very bright, and previously when user dragged the light slider, the user wouldn't get any feedback about just how bright the LED would become, and that presents a safety risk, cause that LED is bright!