### PR TITLE
fix autolamp tooltip

### DIFF
--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -41,10 +41,10 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
                 <div class="range-max">Full</div>
               </div>
-              <div class="input-group hidden" id="autolamp-group">
+              <div class="input-group hidden" id="autolamp-group" title="Lamp only on when camera active">
                 <label for="autolamp">Auto Lamp</label>
                 <div class="switch">
-                  <input id="autolamp" type="checkbox" class="default-action" title="Lamp only on when camera active">
+                  <input id="autolamp" type="checkbox" class="default-action">
                   <label class="slider" for="autolamp"></label>
                 </div>
               </div>

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -41,10 +41,10 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
                 <div class="range-max">Full</div>
               </div>
-              <div class="input-group hidden" id="autolamp-group">
+              <div class="input-group hidden" id="autolamp-group" title="Lamp only on when camera active">
                 <label for="autolamp">Auto Lamp</label>
                 <div class="switch">
-                  <input id="autolamp" type="checkbox" class="default-action" title="Lamp only on when camera active">
+                  <input id="autolamp" type="checkbox" class="default-action">
                   <label class="slider" for="autolamp"></label>
                 </div>
               </div>


### PR DESCRIPTION
Applying the title property to the checkbox didn't properly produce the tooltip of the title when mouse hovered over, but does work if move the title to the parent autolamp-group div.