### PR TITLE
fix prefs label

### DIFF
--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -238,7 +238,7 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
                 </div>
               </div>
               <div class="input-group" id="preferences-group">
-                <label for="reboot" style="line-height: 2em;">Preferences</label>
+                <label for="prefs" style="line-height: 2em;">Preferences</label>
                 <button id="reboot" title="Reboot the camera module">Reboot</button>
                 <button id="save_prefs" title="Save Preferences on camera module">Save</button>
                 <button id="clear_prefs" title="Erase saved Preferences on camera module">Erase</button>

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -252,7 +252,7 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
                 </div>
               </div>
               <div class="input-group" id="preferences-group">
-                <label for="reboot" style="line-height: 2em;">Preferences</label>
+                <label for="prefs" style="line-height: 2em;">Preferences</label>
                 <button id="reboot" title="Reboot the camera module">Reboot</button>
                 <button id="save_prefs" title="Save Preferences on camera module">Save</button>
                 <button id="clear_prefs" title="Erase saved Preferences on camera module">Erase</button>


### PR DESCRIPTION
What was previously written seems unintended.  It meant that hovering over "Preferences" label would result undesirebly in the "Reboot" button being highlighted, and thus clicking on "Preferences" would try to reboot the ESP32.

But by changing the "for=" for the preferences label from "reboot" to "prefs" it is now unique and doesn't get confused with "reboot".