### PR TITLE
Lamp Warning symbol and tooltip

### DIFF
--- a/index_other.h
+++ b/index_other.h
@@ -29,11 +29,11 @@ const uint8_t index_simple_html[] = R"=====(<!doctype html>
         <div class="hidden" id="sidebar">
           <input type="checkbox" id="nav-toggle-cb">
             <nav id="menu" style="width:24em;">
-              <div class="input-group hidden" id="lamp-group">
+              <div class="input-group hidden" id="lamp-group" title="Brightness of flashlight LED. Warning: Very bright! Be careful when increasing. Avoid looking directly at LED!>
                 <label for="lamp">Light</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="action-setting">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group" id="framesize-group">
                 <label for="framesize">Resolution</label>

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -35,11 +35,11 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
         <div class="hidden" id="sidebar">
           <input type="checkbox" id="nav-toggle-cb" checked="checked">
             <nav id="menu">
-              <div class="input-group hidden" id="lamp-group">
+              <div class="input-group hidden" id="lamp-group" title="Brightness of flashlight LED. Warning: Very bright! Be careful when increasing. Avoid looking directly at LED!">
                 <label for="lamp">Light</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group hidden" id="autolamp-group">
                 <label for="autolamp">Auto Lamp</label>

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -35,11 +35,11 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
         <div class="hidden" id="sidebar">
           <input type="checkbox" id="nav-toggle-cb" checked="checked">
             <nav id="menu">
-              <div class="input-group hidden" id="lamp-group">
+              <div class="input-group hidden" id="lamp-group" title="Brightness of flashlight LED. Warning: Very bright! Be careful when increasing. Avoid looking directly at LED!">
                 <label for="lamp">Light</label>
                 <div class="range-min">Off</div>
                 <input type="range" id="lamp" min="0" max="100" value="0" class="default-action">
-                <div class="range-max">Full</div>
+                <div class="range-max">Full&#9888;</div>
               </div>
               <div class="input-group hidden" id="autolamp-group">
                 <label for="autolamp">Auto Lamp</label>


### PR DESCRIPTION
puts the unicode warning symbol ⚠ next to "Full".

adds a tooltip when hovering mouse over any part of the lamp-group div that reads:

"Brightness of flashlight LED. Warning: Very bright! Be careful when increasing. Avoid looking directly at LED!"