### PR TITLE
Platformio OTA partitioning and upload (#160)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,16 @@
 [platformio]
 src_dir = ./
 
-[env:esp32cam]
+[env:esp32dev]
 platform = espressif32
-board = esp32cam
-board_build.partitions = default.csv
+board = esp32dev
+board_build.partitions = min_spiffs.csv
 framework = arduino
+build_flags =
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+; For OTA uploading uncomment the next lines and add the IP address or mDNS name of the camera module, and the OTA password
+;upload_protocol = espota
+;upload_port = <IP or mDNS>
+;upload_flags =
+;    --auth=<OTA PASSWORD>


### PR DESCRIPTION
Platformio OTA compatible partitioning, psram enable
- OTA upload options added (but commented out) in the platformio.ini file
- Tested, seems to work fine