### PR TITLE
Fix rotate -90 degree bug for simple view

### DIFF
--- a/index_other.h
+++ b/index_other.h
@@ -12,7 +12,14 @@ const uint8_t index_simple_html[] = R"=====(<!doctype html>
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <style>
-    // style overrides here
+      @media (min-width: 800px) and (orientation:landscape) {
+        #content {
+          display:flex;
+          flex-wrap: nowrap;
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
     </style>
   </head>
 


### PR DESCRIPTION
Adding a style with flex-direction: column; and align-items: flex-start; does the job 😀
Tested with Chrome and Firefox.