### PR TITLE
Framerate limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ branches:
 before_script:
   - "export DISPLAY=:99.0"
   - sleep 3 # give xvfb some time to start
-  - wget http://downloads.arduino.cc/arduino-1.8.15-linux64.tar.xz
-  - tar xf arduino-1.8.15-linux64.tar.xz
-  - mv arduino-1.8.15 $HOME/arduino_ide
+  - wget https://downloads.arduino.cc/arduino-1.8.18-linux64.tar.xz
+  - tar xf arduino-1.8.18-linux64.tar.xz
+  - mv arduino-1.8.18 $HOME/arduino_ide
   - cd $HOME/arduino_ide/hardware
   - mkdir esp32
   - cd esp32
-  - wget https://github.com/espressif/arduino-esp32/archive/refs/tags/2.0.0.tar.gz
-  - tar -xzf 2.0.0.tar.gz
-  - mv arduino-esp32-2.0.0/ esp32
+  - wget https://github.com/espressif/arduino-esp32/archive/refs/tags/2.0.1.tar.gz
+  - tar -xzf 2.0.1.tar.gz
+  - mv arduino-esp32-2.0.1/ esp32
   - cd esp32/tools
   - python --version
   - python get.py

--- a/API.md
+++ b/API.md
@@ -26,6 +26,7 @@ Call `/control?var=<key>&val=<val>` with a settings key and value to set camera 
 ```
 lamp            - Lamp value in percent; integer, 0 - 100 (-1 = disabled)
 framesize       - See below
+framerate_limit - Minimal frame duration in ms, used to limit max FPS. Must be positive integer
 quality         - 10 to 63 (ov3660: 4 to 10)
 contrast        - -2 to 2 (ov3660: -3 to 3)
 brightness      - -2 to 2 (ov3660: -3 to 3)

--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ Call `/control?var=<key>&val=<val>` with a settings key and value to set camera 
 ```
 lamp            - Lamp value in percent; integer, 0 - 100 (-1 = disabled)
 framesize       - See below
-framerate_limit - Minimal frame duration in ms, used to limit max FPS. Must be positive integer
+min_frame_time  - Minimal frame duration in ms, used to limit max FPS. Must be positive integer
 quality         - 10 to 63 (ov3660: 4 to 10)
 contrast        - -2 to 2 (ov3660: -3 to 3)
 brightness      - -2 to 2 (ov3660: -3 to 3)

--- a/app_httpd.cpp
+++ b/app_httpd.cpp
@@ -237,6 +237,10 @@ static esp_err_t stream_handler(httpd_req_t *req){
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
+    if(res == ESP_OK){
+        res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
+    }
+
     while(true){
         fb = esp_camera_fb_get();
         if (!fb) {

--- a/app_httpd.cpp
+++ b/app_httpd.cpp
@@ -52,7 +52,7 @@ extern int8_t streamCount;
 extern unsigned long streamsServed;
 extern unsigned long imagesServed;
 extern int myRotation;
-extern int framerateLimit;
+extern int minFrameTime;
 extern int lampVal;
 extern bool autoLamp;
 extern bool filesystem;
@@ -276,7 +276,7 @@ static esp_err_t stream_handler(httpd_req_t *req){
         }
         int64_t frame_time = esp_timer_get_time() - last_frame;
         frame_time /= 1000;
-        int32_t frame_delay = (framerateLimit > frame_time) ? framerateLimit - frame_time : 0;
+        int32_t frame_delay = (minFrameTime > frame_time) ? minFrameTime - frame_time : 0;
         delay(frame_delay);
 
         if (debugData) {
@@ -359,7 +359,7 @@ static esp_err_t cmd_handler(httpd_req_t *req){
     else if(!strcmp(variable, "wb_mode")) res = s->set_wb_mode(s, val);
     else if(!strcmp(variable, "ae_level")) res = s->set_ae_level(s, val);
     else if(!strcmp(variable, "rotate")) myRotation = val;
-    else if(!strcmp(variable, "framerate_limit")) framerateLimit = val;
+    else if(!strcmp(variable, "min_frame_time")) minFrameTime = val;
     else if(!strcmp(variable, "autolamp") && (lampVal != -1)) {
         autoLamp = val;
         if (autoLamp) {
@@ -415,7 +415,7 @@ static esp_err_t status_handler(httpd_req_t *req){
     *p++ = '{';
     p+=sprintf(p, "\"lamp\":%d,", lampVal);
     p+=sprintf(p, "\"autolamp\":%d,", autoLamp);
-    p+=sprintf(p, "\"framerate_limit\":%d,", framerateLimit);
+    p+=sprintf(p, "\"min_frame_time\":%d,", minFrameTime);
     p+=sprintf(p, "\"framesize\":%u,", s->status.framesize);
     p+=sprintf(p, "\"quality\":%u,", s->status.quality);
     p+=sprintf(p, "\"brightness\":%d,", s->status.brightness);

--- a/app_httpd.cpp
+++ b/app_httpd.cpp
@@ -252,14 +252,14 @@ static esp_err_t stream_handler(httpd_req_t *req){
             }
         }
         if(res == ESP_OK){
-            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
-        }
-        if(res == ESP_OK){
             size_t hlen = snprintf((char *)part_buf, 64, _STREAM_PART, _jpg_buf_len);
             res = httpd_resp_send_chunk(req, (const char *)part_buf, hlen);
         }
         if(res == ESP_OK){
             res = httpd_resp_send_chunk(req, (const char *)_jpg_buf, _jpg_buf_len);
+        }
+        if(res == ESP_OK){
+            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
         }
         if(fb){
             esp_camera_fb_return(fb);

--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -147,6 +147,12 @@ char myVer[] PROGMEM = __DATE__ " @ " __TIME__;
 #endif
 int myRotation = CAM_ROTATION;
 
+// minimal frame duration in ms, effectively 1/maxFPS
+#if !defined(FRAMERATE_LIMIT)
+    #define FRAMERATE_LIMIT 0
+#endif
+int framerateLimit = FRAMERATE_LIMIT;
+
 // Illumination LAMP and status LED
 #if defined(LAMP_DISABLE)
     int lampVal = -1; // lamp is disabled in config

--- a/esp32-cam-webserver.ino
+++ b/esp32-cam-webserver.ino
@@ -148,10 +148,10 @@ char myVer[] PROGMEM = __DATE__ " @ " __TIME__;
 int myRotation = CAM_ROTATION;
 
 // minimal frame duration in ms, effectively 1/maxFPS
-#if !defined(FRAMERATE_LIMIT)
-    #define FRAMERATE_LIMIT 0
+#if !defined(MIN_FRAME_TIME)
+    #define MIN_FRAME_TIME 0
 #endif
-int framerateLimit = FRAMERATE_LIMIT;
+int minFrameTime = MIN_FRAME_TIME;
 
 // Illumination LAMP and status LED
 #if defined(LAMP_DISABLE)

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -238,16 +238,16 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
                 </div>
               </div>
               <div class="input-group" id="min_frame_time-group">
-                <label for="min_frame_time">FPS Limit</label>
+                <label for="min_frame_time">Frame Duration Limit</label>
                 <select id="min_frame_time" class="default-action">
-                  <option value="3333">0.3</option>
-                  <option value="2000">0.5</option>
-                  <option value="1000">1</option>
-                  <option value="500">2</option>
-                  <option value="333">3</option>
-                  <option value="200">5</option>
-                  <option value="100">10</option>
-                  <option value="50">20</option>
+                  <option value="3333">3333ms (0.3fps)</option>
+                  <option value="2000">2000ms (0.5fps)</option>
+                  <option value="1000">1000ms (1fps)</option>
+                  <option value="500">500ms (2fps)</option>
+                  <option value="333">333ms (3fps)</option>
+                  <option value="200">200ms (5fps)</option>
+                  <option value="100">100ms (10fps)</option>
+                  <option value="50">50ms (20fps)</option>
                   <option value="0" selected="selected">Disabled</option>
                 </select>
               </div>

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -237,6 +237,20 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
                   <label class="slider" for="colorbar"></label>
                 </div>
               </div>
+              <div class="input-group" id="framerate_limit-group">
+                <label for="framerate_limit">FPS Limit</label>
+                <select id="framerate_limit" class="default-action">
+                  <option value="3333">0.3</option>
+                  <option value="2000">0.5</option>
+                  <option value="1000">1</option>
+                  <option value="500">2</option>
+                  <option value="333">3</option>
+                  <option value="200">5</option>
+                  <option value="100">10</option>
+                  <option value="50">20</option>
+                  <option value="0" selected="selected">Disabled</option>
+                </select>
+              </div>
               <div class="input-group" id="preferences-group">
                 <label for="reboot" style="line-height: 2em;">Preferences</label>
                 <button id="reboot" title="Reboot the camera module">Reboot</button>
@@ -296,6 +310,7 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
     const savePrefsButton = document.getElementById('save_prefs')
     const clearPrefsButton = document.getElementById('clear_prefs')
     const rebootButton = document.getElementById('reboot')
+    const framerateLimit = document.getElementById('framerate_limit')
 
     const hide = el => {
       el.classList.add('hidden')
@@ -359,6 +374,8 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
         } else if(el.id === "rotate"){
           rotate.value = value;
           applyRotation();
+        } else if(el.id === "framerate_limit"){
+          framerate_limit.value = value;
         } else if(el.id === "stream_url"){
           streamURL = value;
           viewerURL = value + 'view';
@@ -560,6 +577,10 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
 
     framesize.onchange = () => {
       updateConfig(framesize)
+    }
+
+    framerateLimit.onchange = () => {
+      updateConfig(framerateLimit)
     }
 
     swapButton.onclick = () => {

--- a/index_ov2640.h
+++ b/index_ov2640.h
@@ -237,9 +237,9 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
                   <label class="slider" for="colorbar"></label>
                 </div>
               </div>
-              <div class="input-group" id="framerate_limit-group">
-                <label for="framerate_limit">FPS Limit</label>
-                <select id="framerate_limit" class="default-action">
+              <div class="input-group" id="min_frame_time-group">
+                <label for="min_frame_time">FPS Limit</label>
+                <select id="min_frame_time" class="default-action">
                   <option value="3333">0.3</option>
                   <option value="2000">0.5</option>
                   <option value="1000">1</option>
@@ -310,7 +310,7 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
     const savePrefsButton = document.getElementById('save_prefs')
     const clearPrefsButton = document.getElementById('clear_prefs')
     const rebootButton = document.getElementById('reboot')
-    const framerateLimit = document.getElementById('framerate_limit')
+    const minFrameTime = document.getElementById('min_frame_time')
 
     const hide = el => {
       el.classList.add('hidden')
@@ -374,8 +374,8 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
         } else if(el.id === "rotate"){
           rotate.value = value;
           applyRotation();
-        } else if(el.id === "framerate_limit"){
-          framerate_limit.value = value;
+        } else if(el.id === "min_frame_time"){
+          min_frame_time.value = value;
         } else if(el.id === "stream_url"){
           streamURL = value;
           viewerURL = value + 'view';
@@ -579,8 +579,8 @@ const uint8_t index_ov2640_html[] = R"=====(<!doctype html>
       updateConfig(framesize)
     }
 
-    framerateLimit.onchange = () => {
-      updateConfig(framerateLimit)
+    minFrameTime.onchange = () => {
+      updateConfig(minFrameTime)
     }
 
     swapButton.onclick = () => {

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -251,9 +251,9 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
                   <label class="slider" for="colorbar"></label>
                 </div>
               </div>
-              <div class="input-group" id="framerate_limit-group">
-                <label for="framerate_limit">FPS Limit</label>
-                <select id="framerate_limit" class="default-action">
+              <div class="input-group" id="min_frame_time-group">
+                <label for="min_frame_time">FPS Limit</label>
+                <select id="min_frame_time" class="default-action">
                   <option value="3333">0.3</option>
                   <option value="2000">0.5</option>
                   <option value="1000">1</option>
@@ -324,7 +324,7 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
     const savePrefsButton = document.getElementById('save_prefs')
     const clearPrefsButton = document.getElementById('clear_prefs')
     const rebootButton = document.getElementById('reboot')
-    const framerateLimit = document.getElementById('framerate_limit')
+    const minFrameTime = document.getElementById('min_frame_time')
 
     const hide = el => {
       el.classList.add('hidden')
@@ -386,8 +386,8 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
         } else if(el.id === "rotate"){
           rotate.value = value;
           applyRotation();
-        } else if(el.id === "framerate_limit"){
-          framerate_limit.value = value;
+        } else if(el.id === "min_frame_time"){
+          min_frame_time.value = value;
         } else if(el.id === "stream_url"){
           streamURL = value;
           viewerURL = value + 'view';
@@ -588,8 +588,8 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
       updateConfig(framesize)
     }
 
-    framerateLimit.onchange = () => {
-      updateConfig(framerateLimit)
+    minFrameTime.onchange = () => {
+      updateConfig(minFrameTime)
     }
 
     swapButton.onclick = () => {

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -251,6 +251,20 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
                   <label class="slider" for="colorbar"></label>
                 </div>
               </div>
+              <div class="input-group" id="framerate_limit-group">
+                <label for="framerate_limit">FPS Limit</label>
+                <select id="framerate_limit" class="default-action">
+                  <option value="3333">0.3</option>
+                  <option value="2000">0.5</option>
+                  <option value="1000">1</option>
+                  <option value="500">2</option>
+                  <option value="333">3</option>
+                  <option value="200">5</option>
+                  <option value="100">10</option>
+                  <option value="50">20</option>
+                  <option value="0" selected="selected">Disabled</option>
+                </select>
+              </div>
               <div class="input-group" id="preferences-group">
                 <label for="reboot" style="line-height: 2em;">Preferences</label>
                 <button id="reboot" title="Reboot the camera module">Reboot</button>
@@ -310,6 +324,7 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
     const savePrefsButton = document.getElementById('save_prefs')
     const clearPrefsButton = document.getElementById('clear_prefs')
     const rebootButton = document.getElementById('reboot')
+    const framerateLimit = document.getElementById('framerate_limit')
 
     const hide = el => {
       el.classList.add('hidden')
@@ -371,6 +386,8 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
         } else if(el.id === "rotate"){
           rotate.value = value;
           applyRotation();
+        } else if(el.id === "framerate_limit"){
+          framerate_limit.value = value;
         } else if(el.id === "stream_url"){
           streamURL = value;
           viewerURL = value + 'view';
@@ -569,6 +586,10 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
 
     framesize.onchange = () => {
       updateConfig(framesize)
+    }
+
+    framerateLimit.onchange = () => {
+      updateConfig(framerateLimit)
     }
 
     swapButton.onclick = () => {

--- a/index_ov3660.h
+++ b/index_ov3660.h
@@ -252,16 +252,16 @@ const uint8_t index_ov3660_html[] = R"=====(<!doctype html>
                 </div>
               </div>
               <div class="input-group" id="min_frame_time-group">
-                <label for="min_frame_time">FPS Limit</label>
+                <label for="min_frame_time">Frame Duration Limit</label>
                 <select id="min_frame_time" class="default-action">
-                  <option value="3333">0.3</option>
-                  <option value="2000">0.5</option>
-                  <option value="1000">1</option>
-                  <option value="500">2</option>
-                  <option value="333">3</option>
-                  <option value="200">5</option>
-                  <option value="100">10</option>
-                  <option value="50">20</option>
+                  <option value="3333">3333ms (0.3fps)</option>
+                  <option value="2000">2000ms (0.5fps)</option>
+                  <option value="1000">1000ms (1fps)</option>
+                  <option value="500">500ms (2fps)</option>
+                  <option value="333">333ms (3fps)</option>
+                  <option value="200">200ms (5fps)</option>
+                  <option value="100">100ms (10fps)</option>
+                  <option value="50">50ms (20fps)</option>
                   <option value="0" selected="selected">Disabled</option>
                 </select>
               </div>

--- a/myconfig.sample.h
+++ b/myconfig.sample.h
@@ -143,6 +143,9 @@ struct station stationList[] = {{"ssid1", "pass1", true},
 // Browser Rotation (one of: -90,0,90, default 0)
 // #define CAM_ROTATION 0
 
+// Minimal frame duration in ms, used to limit max FPS
+// max_fps = 1000/framerate_limit
+// #define FRAMERATE_LIMIT 500
 
 /*
  * Additional Features

--- a/myconfig.sample.h
+++ b/myconfig.sample.h
@@ -144,8 +144,8 @@ struct station stationList[] = {{"ssid1", "pass1", true},
 // #define CAM_ROTATION 0
 
 // Minimal frame duration in ms, used to limit max FPS
-// max_fps = 1000/framerate_limit
-// #define FRAMERATE_LIMIT 500
+// max_fps = 1000/min_frame_time
+// #define MIN_FRAME_TIME 500
 
 /*
  * Additional Features

--- a/storage.cpp
+++ b/storage.cpp
@@ -7,6 +7,7 @@ extern void flashLED(int flashtime);
 extern int myRotation;              // Rotation
 extern int lampVal;                 // The current Lamp value
 extern int autoLamp;                // Automatic lamp mode
+extern int framerateLimit;          // Minimal frame duration
 
 /*
  * Useful utility when debugging... 
@@ -90,6 +91,7 @@ void loadPrefs(fs::FS &fs){
     // process all the settings
     lampVal = jsonExtract(prefs, "lamp").toInt();
     autoLamp = jsonExtract(prefs, "autolamp").toInt();
+    framerateLimit = jsonExtract(prefs, "framerate_limit").toInt();
     s->set_framesize(s, (framesize_t)jsonExtract(prefs, "framesize").toInt());
     s->set_quality(s, jsonExtract(prefs, "quality").toInt());
     s->set_brightness(s, jsonExtract(prefs, "brightness").toInt());
@@ -136,6 +138,7 @@ void savePrefs(fs::FS &fs){
   *p++ = '{';
   p+=sprintf(p, "\"lamp\":%i,", lampVal);
   p+=sprintf(p, "\"autolamp\":%u,", autoLamp);
+  p+=sprintf(p, "\"framerate_limit\":%d,", framerateLimit);
   p+=sprintf(p, "\"framesize\":%u,", s->status.framesize);
   p+=sprintf(p, "\"quality\":%u,", s->status.quality);
   p+=sprintf(p, "\"brightness\":%d,", s->status.brightness);

--- a/storage.cpp
+++ b/storage.cpp
@@ -7,7 +7,7 @@ extern void flashLED(int flashtime);
 extern int myRotation;              // Rotation
 extern int lampVal;                 // The current Lamp value
 extern int autoLamp;                // Automatic lamp mode
-extern int framerateLimit;          // Minimal frame duration
+extern int minFrameTime;            // Minimal frame duration
 
 /*
  * Useful utility when debugging... 
@@ -91,7 +91,7 @@ void loadPrefs(fs::FS &fs){
     // process all the settings
     lampVal = jsonExtract(prefs, "lamp").toInt();
     autoLamp = jsonExtract(prefs, "autolamp").toInt();
-    framerateLimit = jsonExtract(prefs, "framerate_limit").toInt();
+    minFrameTime = jsonExtract(prefs, "min_frame_time").toInt();
     s->set_framesize(s, (framesize_t)jsonExtract(prefs, "framesize").toInt());
     s->set_quality(s, jsonExtract(prefs, "quality").toInt());
     s->set_brightness(s, jsonExtract(prefs, "brightness").toInt());
@@ -138,7 +138,7 @@ void savePrefs(fs::FS &fs){
   *p++ = '{';
   p+=sprintf(p, "\"lamp\":%i,", lampVal);
   p+=sprintf(p, "\"autolamp\":%u,", autoLamp);
-  p+=sprintf(p, "\"framerate_limit\":%d,", framerateLimit);
+  p+=sprintf(p, "\"min_frame_time\":%d,", minFrameTime);
   p+=sprintf(p, "\"framesize\":%u,", s->status.framesize);
   p+=sprintf(p, "\"quality\":%u,", s->status.quality);
   p+=sprintf(p, "\"brightness\":%d,", s->status.brightness);


### PR DESCRIPTION
Allow to limit stream framerate in order to make it stable and lower load on the board for usecases where high fps is not required.
In order to keep code simple limit is set not in frames per second but in milliseconds between frames to make it integer.
Web-interface uses drop-down list with set of pre-defined fps values.